### PR TITLE
Handle OpenGL debug message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 tmp/
 build
 .cache
+.vscode
+CMakeUserPresets.json
+compile_commands.json

--- a/include/graphics/renderer.h
+++ b/include/graphics/renderer.h
@@ -2,6 +2,8 @@
 #include "graphics/shader.h"
 #include "graphics/vertex_storage.h"
 
+#include <spdlog/spdlog.h>
+
 #include <vector>
 
 namespace arch {
@@ -16,13 +18,10 @@ private:
     VertexStorage _vertex_storage;
 
 };
-    
-/*
-  * Base class for renderers that contains functionality common to 3D and 2D rendering.
-  */
-class Renderer {
-protected:
-    Renderer();
+
+class OpenGLDebugMessagesHandler {
+public:
+    static void init();
 private:
     static void GLAPIENTRY
     _debug_message_callback(
@@ -34,7 +33,20 @@ private:
         const GLchar *message,
         const void *user_param
     );
-                
+    static spdlog::level::level_enum _determine_log_level(GLenum type, GLenum severity);
+
+    static constexpr std::array<GLenum, 10> _warning_message_types {
+        GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR,  GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR,
+        GL_DEBUG_TYPE_PORTABILITY,  GL_DEBUG_TYPE_PERFORMANCE
+    };
+};
+    
+/*
+  * Base class for renderers that contains functionality common to 3D and 2D rendering.
+  */
+class Renderer {
+protected:
+    Renderer();
 };
 
 class Renderer3D : public Renderer {

--- a/include/graphics/renderer.h
+++ b/include/graphics/renderer.h
@@ -20,12 +20,25 @@ private:
 /*
   * Base class for renderers that contains functionality common to 3D and 2D rendering.
   */
-class Renderer {};
+class Renderer {
+protected:
+    Renderer();
+private:
+    static void GLAPIENTRY
+    _debug_message_callback(
+        GLenum source,
+        GLenum type,
+        GLuint id,
+        GLenum severity,
+        GLsizei length,
+        const GLchar *message,
+        const void *user_param
+    );
+                
+};
 
 class Renderer3D : public Renderer {
 public:
-    Renderer3D();
-
     void render();
     void submit(const Model &model);
 

--- a/src/graphics/buffer_object.cpp
+++ b/src/graphics/buffer_object.cpp
@@ -1,7 +1,5 @@
 #include "graphics/buffer_object.h"
 
-#include <spdlog/spdlog.h>
-
 namespace arch {
 
 VertexArray::VertexArray() {

--- a/src/graphics/renderer.cpp
+++ b/src/graphics/renderer.cpp
@@ -4,7 +4,17 @@
 
 namespace arch {
 
-Renderer3D::Renderer3D() {
+
+Renderer::Renderer() {
+    glEnable(GL_DEBUG_OUTPUT);
+}
+
+void GLAPIENTRY Renderer::_debug_message_callback(GLenum source, GLenum type,
+												  GLuint id, GLenum severity,
+												  GLsizei length,
+												  const GLchar *message,
+												  const void *user_param) {
+   
 }
 
 void Renderer3D::render() {


### PR DESCRIPTION
Closes #39 
Logs useful for debugging OpenGL messages using callback-based API. `glGetError()` not really needed anymore from now on.
![image](https://github.com/AGH-Code-Industry/archimedes/assets/54525984/ff92ba32-ae65-4612-a2ae-6d42887f1e24)
