### PR TITLE
Fix logger warning

### DIFF
--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -28,7 +28,7 @@ void Logger::init(LogLevel logLevel, const std::string& name) {
 	{
 		// Add a file sink
 		char logPath[256];
-		std::snprintf(logPath, sizeof(logPath), "Logs/%s-%lld.log", name.c_str(), std::time(nullptr));
+		std::snprintf(logPath, sizeof(logPath), "Logs/%s-%lld.log", name.c_str(), (long long)std::time(nullptr));
 
 		auto sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(logPath, true);
 		sink->set_pattern("[%T] [%l] [%@]: %v");


### PR DESCRIPTION
![image](https://github.com/AGH-Code-Industry/archimedes/assets/72704303/7b8dc6d0-dee7-4de3-a0fd-2c7bc7ab4d2c)

Naprawiono rzutując `std::time(nullptr)` na `long long`