### PR TITLE
Update .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -33,7 +33,7 @@ IndentRequiresClause: true
 IndentWrappedFunctionNames: false
 LambdaBodyIndentation: Signature
 RequiresClausePosition: WithPreceding
-RequiresExpressionIndentation: Keyword
+RequiresExpressionIndentation: OuterScope
 
 InsertBraces: true
 InsertTrailingCommas: Wrapped


### PR DESCRIPTION
Changed `RequiresExpressionIndentation` in `.clang-format` from `Keyword` to `OuterScope`

Before 🤮:
![image](https://github.com/user-attachments/assets/2086411a-1280-4e60-83cf-1fe583f437fb)


After:
![image](https://github.com/user-attachments/assets/e402ba20-bedc-4da3-b678-af3789b087ed)
