### PR TITLE
Fixed ECS bugs

### DIFF
--- a/include/ecs/ComponentPool.hpp
+++ b/include/ecs/ComponentPool.hpp
@@ -133,7 +133,7 @@ C POOL_C::removeComponent(const EntityT entity, MoveFlag) noexcept requires(std:
 		if (&sparseSwap != &fromSparse) {
 			// first sparse swap, id at listHead = id of given entity
 			sparseSwap =
-				ETraits::Ent::fromRawParts(ETraits::Id::rawPart(entity), ETraits::Version::rawPart(sparseSwap));
+				ETraits::Ent::fromRawParts(ETraits::Id::rawPart(fromSparse), ETraits::Version::rawPart(sparseSwap));
 		}
 		// second sparse swap, entity at id = null
 		// also obtain index to dense
@@ -183,7 +183,7 @@ bool POOL_C::removeComponent(const EntityT entity) noexcept {
 		if (&sparseSwap != sparsePtr) {
 			// first sparse swap, id at listHead = id of given entity
 			sparseSwap =
-				ETraits::Ent::fromRawParts(ETraits::Id::rawPart(entity), ETraits::Version::rawPart(sparseSwap));
+				ETraits::Ent::fromRawParts(ETraits::Id::rawPart(*sparsePtr), ETraits::Version::rawPart(sparseSwap));
 		}
 		// second sparse swap, entity at id = null
 		// also obtain index to dense

--- a/src/ecs/EntityPool.cpp
+++ b/src/ecs/EntityPool.cpp
@@ -73,7 +73,9 @@ EntityPool::EntityT EntityPool::newEntity() noexcept {
 		return entity;
 	} else { // recycle
 		const auto entity = _dense[_size++];
-		_sparseGet(Traits::Id::part(entity)) = entity;
+		auto&& inSparse = _sparseGet(Traits::Id::part(entity));
+
+		inSparse = Traits::Ent::fromOthers(inSparse, entity);
 
 		return entity;
 	}


### PR DESCRIPTION
Fixed EntityPool assigning ID & Version from dense to sparse (instead of assigning only Version) while recycling entities
Fixed ComponentPool using given ID instead of sparse ID while doing first swap in removeComponent