### PR TITLE
Transfering application ownership to Engine

### DIFF
--- a/archimedes_bin/main.cpp
+++ b/archimedes_bin/main.cpp
@@ -13,6 +13,6 @@ int main() {
 							   .backgroundColor = arch::Color(.0f, .0f, .0f, 1.f),
 							   .renderingApi = arch::gfx::RenderingAPI::Nvrhi_VK };
 
-	arch::Engine engine{ config, std::move(myApp) };
+	arch::Engine engine{ config, myApp };
 	engine.start();
 }

--- a/archimedes_bin/main.cpp
+++ b/archimedes_bin/main.cpp
@@ -5,7 +5,7 @@
 int main() {
 	arch::Logger::init(arch::LogLevel::trace);
 
-	arch::Ref<arch::Application> myApp = arch::createRef<TextRenderTestApp>();
+	arch::UniqueRef<arch::Application> myApp = arch::createUnique<TextRenderTestApp>();
 
 	arch::EngineConfig config{ .windowWidth = 1'200,
 							   .windowHeight = 600,
@@ -13,6 +13,6 @@ int main() {
 							   .backgroundColor = arch::Color(.0f, .0f, .0f, 1.f),
 							   .renderingApi = arch::gfx::RenderingAPI::Nvrhi_VK };
 
-	arch::Engine engine{ config, myApp };
+	arch::Engine engine{ config, std::move(myApp) };
 	engine.start();
 }

--- a/archimedes_bin/main.cpp
+++ b/archimedes_bin/main.cpp
@@ -5,7 +5,7 @@
 int main() {
 	arch::Logger::init(arch::LogLevel::trace);
 
-	arch::UniqueRef<arch::Application> myApp = arch::createUnique<TextRenderTestApp>();
+	arch::Unique<arch::Application> myApp = arch::createUnique<TextRenderTestApp>();
 
 	arch::EngineConfig config{ .windowWidth = 1'200,
 							   .windowHeight = 600,

--- a/cmake/targets/archimedes_bin.cmake
+++ b/cmake/targets/archimedes_bin.cmake
@@ -5,5 +5,9 @@ include("${PROJECT_SOURCE_DIR}/cmake/library.cmake")
 file(GLOB_RECURSE ARCHIMEDES_BIN_SOURCE CONFIGURE_DEPENDS archimedes_bin/**.cpp)
 add_executable(${PROJECT_NAME}_bin ${ARCHIMEDES_BIN_SOURCE})
 
+set_target_properties(${PROJECT_NAME}_bin PROPERTIES
+    VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/run"
+)
+
 target_include_directories(${PROJECT_NAME}_bin PUBLIC archimedes_bin)
 target_link_libraries(${PROJECT_NAME}_bin PUBLIC ${PROJECT_NAME})

--- a/include/Engine.h
+++ b/include/Engine.h
@@ -26,7 +26,7 @@ struct EngineConfig {
  */
 class Engine {
 public:
-	Engine(const EngineConfig& config, const Ref<Application>& application);
+	Engine(const EngineConfig& config, UniqueRef<Application> application);
 	~Engine();
 
 	/**
@@ -35,12 +35,12 @@ public:
 	void start();
 
 private:
-	Ref<Window> _mainWindow;
-	EngineConfig _engineConfig;
-	Ref<gfx::Renderer> _renderer;
-	Ref<Application> _application;
 
-	Ref<scene::SceneManager> _sceneManager;
+	EngineConfig _engineConfig; 
+	Ref<Window> _mainWindow;
+	Ref<gfx::Renderer> _renderer; 
+	Ref<scene::SceneManager> _sceneManager; 
+	UniqueRef<Application> _application;
 
 private:
 	/**

--- a/include/Engine.h
+++ b/include/Engine.h
@@ -26,7 +26,7 @@ struct EngineConfig {
  */
 class Engine {
 public:
-	Engine(const EngineConfig& config, UniqueRef<Application> application);
+	Engine(const EngineConfig& config, Unique<Application> application);
 	~Engine();
 
 	/**
@@ -40,7 +40,7 @@ private:
 	Ref<Window> _mainWindow;
 	Ref<gfx::Renderer> _renderer; 
 	Ref<scene::SceneManager> _sceneManager; 
-	UniqueRef<Application> _application;
+	Unique<Application> _application;
 
 private:
 	/**

--- a/include/Engine.h
+++ b/include/Engine.h
@@ -26,7 +26,7 @@ struct EngineConfig {
  */
 class Engine {
 public:
-	Engine(const EngineConfig& config, Unique<Application> application);
+	Engine(const EngineConfig& config, Unique<Application>& application);
 	~Engine();
 
 	/**

--- a/include/Ref.h
+++ b/include/Ref.h
@@ -11,7 +11,7 @@ template<typename T>
 using WeakRef = std::weak_ptr<T>;
 
 template<typename T>
-using UniqueRef = std::unique_ptr<T>;
+using Unique = std::unique_ptr<T>;
 
 template<typename T, typename... Args>
 requires std::constructible_from<T, Args...>
@@ -27,7 +27,7 @@ constexpr Ref<T> createRef(T* ptr) {
 
 template<typename T, typename... Args>
 requires std::constructible_from<T, Args...>
-constexpr UniqueRef<T> createUnique(Args&&... args) {
+constexpr Unique<T> createUnique(Args&&... args) {
 	return std::make_unique<T>(std::forward<Args>(args)...);
 }
 

--- a/include/Ref.h
+++ b/include/Ref.h
@@ -10,6 +10,9 @@ using Ref = std::shared_ptr<T>;
 template<typename T>
 using WeakRef = std::weak_ptr<T>;
 
+template<typename T>
+using UniqueRef = std::unique_ptr<T>;
+
 template<typename T, typename... Args>
 requires std::constructible_from<T, Args...>
 constexpr Ref<T> createRef(Args&&... args) {
@@ -20,6 +23,12 @@ template<typename T>
 requires std::derived_from<T, std::enable_shared_from_this<T>>
 constexpr Ref<T> createRef(T* ptr) {
 	return ptr->shared_from_this();
+}
+
+template<typename T, typename... Args>
+requires std::constructible_from<T, Args...>
+constexpr UniqueRef<T> createUnique(Args&&... args) {
+	return std::make_unique<T>(std::forward<Args>(args)...);
 }
 
 } // namespace arch

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -72,6 +72,7 @@ void Engine::_initialize() {
 }
 
 void Engine::_shutdown() {
+	_application.reset();
 	font::FontDB::_singleton.reset();
 	scene::SceneManager::get()->shutdown();
 

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -11,9 +11,9 @@
 
 namespace arch {
 
-Engine::Engine(const EngineConfig& config, const Ref<Application>& application):
+Engine::Engine(const EngineConfig& config, UniqueRef<Application> application):
 	_engineConfig{ config },
-	_application{ application } {}
+	_application{ std::move(application) } {}
 
 Engine::~Engine() {
 	_shutdown();
@@ -22,7 +22,7 @@ Engine::~Engine() {
 void Engine::start() {
 	try {
 		_initialize();
-
+		
 		_mainLoop();
 	} catch (Exception& e) {
 		e.print();

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -11,7 +11,7 @@
 
 namespace arch {
 
-Engine::Engine(const EngineConfig& config, UniqueRef<Application> application):
+Engine::Engine(const EngineConfig& config, Unique<Application> application):
 	_engineConfig{ config },
 	_application{ std::move(application) } {}
 

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -11,7 +11,7 @@
 
 namespace arch {
 
-Engine::Engine(const EngineConfig& config, Unique<Application> application):
+Engine::Engine(const EngineConfig& config, Unique<Application>& application):
 	_engineConfig{ config },
 	_application{ std::move(application) } {}
 


### PR DESCRIPTION
1. Create unique_ptr alias.
2. Replace shared_ptr (Ref) with unique_ptr (UniqueRef) for Application.
3. Ensure Engine fully owns the application instance.
4. Set working directory for archimedes_bin target.