### PR TITLE
Fix source assigning and logging

### DIFF
--- a/src/audio/AudioManager.cpp
+++ b/src/audio/AudioManager.cpp
@@ -63,7 +63,7 @@ void AudioManager::playSource(AudioSourceComponent& source) {
 		throw AudioException("Audio manager can't play not registered source");
 	}
 	SourceState currentState = _sourceStates[source._id];
-	if (currentState == unused || currentState == paused || currentState == assigned) {
+	if (currentState == paused || currentState == assigned) {
 		_sourceStates[source._id] = playing;
 	}
 }

--- a/src/audio/AudioManager.cpp
+++ b/src/audio/AudioManager.cpp
@@ -112,7 +112,7 @@ void AudioManager::assignSource(AudioSourceComponent& source) {
 	_sources[index].setClipPath(source.path);
 	_sources[index].update(source);
 	_sourceStates[index] = assigned;
-	Logger::info("Audio system: audio manager assigned Source with index {}", std::to_string(index));
+	Logger::info("Audio system: audio manager assigned Source with index {}", index);
 }
 
 
@@ -126,7 +126,7 @@ void AudioManager::assignSource(AudioSourceComponent& source, const scene::compo
 	_sources[index].setClipPath(source.path);
 	_sources[index].update(source, transform, moveable);
 	_sourceStates[index] = assigned;
-	Logger::info("Audio system: audio manager assigned Source with index {}", std::to_string(index));
+	Logger::info("Audio system: audio manager assigned Source with index {}", index);
 }
 
 void AudioManager::synchronize(ecs::Domain& domain) {
@@ -143,7 +143,7 @@ void AudioManager::synchronize(ecs::Domain& domain) {
 		if (_sourceStates[audioSource._id] == removed) {
 			_sourceStates[audioSource._id] = unused;
 			_dontRemoveFinished[audioSource._id] = false;
-			Logger::info("Audio system: audio manager removed Source with index {}", std::to_string(audioSource._id));
+			Logger::info("Audio system: audio manager removed Source with index {}", audioSource._id);
 			audioSource._id = -1;
 		}
 		else if (transform.hasValue() && moveable.hasValue()) {
@@ -157,7 +157,7 @@ void AudioManager::synchronize(ecs::Domain& domain) {
 		if (_sourceStates[source] == removed) {
 			_sourceStates[source] = unused;
 			_dontRemoveFinished[source] = false;
-			Logger::info("Audio system: audio manager removed Source with index {}", std::to_string(source));
+			Logger::info("Audio system: audio manager removed Source with index {}", source);
 
 		}
 	}

--- a/src/audio/AudioManager.cpp
+++ b/src/audio/AudioManager.cpp
@@ -125,6 +125,7 @@ void AudioManager::assignSource(AudioSourceComponent& source, const scene::compo
 	source._id = index;
 	_sources[index].setClipPath(source.path);
 	_sources[index].update(source, transform, moveable);
+	_sourceStates[index] = assigned;
 	Logger::info("Audio system: audio manager assigned Source with index {}", std::to_string(index));
 }
 

--- a/src/audio/SoundBank.cpp
+++ b/src/audio/SoundBank.cpp
@@ -7,7 +7,7 @@ namespace arch::audio {
 void SoundBank::loadGroup(int group) {
 	auto entryFound = _groups.find(group);
 	if (entryFound == _groups.end()) {
-		throw AudioException("Can't find sound bank group with id " + std::to_string(group));
+		throw AudioException("Can't find sound bank group with id " + group);
 	}
 	if (_isLoaded[entryFound->first]) {
 		throw AudioException("Can't load sound bank group: " + std::to_string(group) + " - it's already loaded");
@@ -21,7 +21,7 @@ void SoundBank::loadGroup(int group) {
 		clipFound->second.load();
 	}
 	_isLoaded[entryFound->first] = true;
-	Logger::info("Audio system: loaded sound bank group with id {}", std::to_string(group));
+	Logger::info("Audio system: loaded sound bank group with id {}", group);
 }
 
 void SoundBank::unloadGroup(int group) {
@@ -42,7 +42,7 @@ void SoundBank::unloadGroup(int group) {
 		clipFound->second.unload();
 	}
 	_isLoaded[entryFound->first] = false;
-	Logger::info("Audio system: unloaded sound bank group with id {}", std::to_string(group));
+	Logger::info("Audio system: unloaded sound bank group with id {}", group);
 }
 
 void SoundBank::loadInitialGroups() {
@@ -96,7 +96,7 @@ void SoundBank::addClip(const std::string& sound, int group) {
 	fs::path clipPath = soundsDirectory / sound;
 	_clips.try_emplace(sound, clipPath.string());
 	_addToGroup(sound, group);
-	Logger::info("Audio system: added clip {} to sound bank group {}", sound, std::to_string(group));
+	Logger::info("Audio system: added clip {} to sound bank group {}", sound, group);
 }
 
 void SoundBank::removeClip(const std::string& sound) {
@@ -114,11 +114,11 @@ void SoundBank::removeClip(const std::string& sound) {
 void SoundBank::setInitial(int group, bool isInitial) {
 	if (isInitial) {
 		_initialGroups.emplace(group);
-		Logger::info("Audio system: sound bank group {} set as initial", std::to_string(group));
+		Logger::info("Audio system: sound bank group {} set as initial", group);
 		return;
 	}
 	_initialGroups.erase(group);
-	Logger::info("Audio system: sound bank group {} unset as initial", std::to_string(group));
+	Logger::info("Audio system: sound bank group {} unset as initial", group);
 }
 
 void SoundBank::addGroup(int group, bool isInitial) {
@@ -130,9 +130,9 @@ void SoundBank::addGroup(int group, bool isInitial) {
 	_isLoaded[group] = false;
 	if (isInitial) {
 		_initialGroups.emplace(group);
-		Logger::info("Audio system: added sound bank group {} as initial", std::to_string(group));
+		Logger::info("Audio system: added sound bank group {} as initial", group);
 	} else {
-		Logger::info("Audio system: added sound bank group {} as not initial", std::to_string(group));
+		Logger::info("Audio system: added sound bank group {} as not initial", group);
 	}
 }
 
@@ -153,7 +153,7 @@ void SoundBank::removeGroup(int group) {
 	}
 	_isLoaded.erase(group);
 	_groups.erase(group);
-	Logger::info("Audio system: removed sound bank group {}", std::to_string(group));
+	Logger::info("Audio system: removed sound bank group {}", group);
 }
 
 void SoundBank::moveClipToGroup(const std::string& sound, int destinationGroup) {
@@ -166,7 +166,7 @@ void SoundBank::moveClipToGroup(const std::string& sound, int destinationGroup) 
 	}
 	_removeFromGroup(sound, sourceGroup);
 	_addToGroup(sound, destinationGroup);
-	Logger::info("Audio system: moved clip {} to sound bank group {}", sound, std::to_string(destinationGroup));
+	Logger::info("Audio system: moved clip {} to sound bank group {}", sound, destinationGroup);
 }
 
 void SoundBank::_addToGroup(const std::string& sound, int group) {


### PR DESCRIPTION
I needlessly used std::to_string while passing integers to the Logger. Also, I forgot to add a line in assignSource that changed the audio source's state to assigned. The playSource also worked when the state is unused. I removed a line allowing it, since now it's useless.