### PR TITLE
Added precompiled headers

### DIFF
--- a/cmake/library.cmake
+++ b/cmake/library.cmake
@@ -3,9 +3,20 @@ include_guard()
 include("${PROJECT_SOURCE_DIR}/cmake/conan.cmake")
 
 add_library(${PROJECT_NAME})
+target_precompile_headers(${PROJECT_NAME} PUBLIC "include/pch.h")
 
 # find source files
 file(GLOB_RECURSE ARCHIMEDES_SOURCE CONFIGURE_DEPENDS src/**.cpp src/platform/**.h)
+
+# remove pch.cpp
+# msvc needs it
+# gcc/clang don't use it
+if(NOT MSVC)
+	file(GLOB_RECURSE ARCHIMEDES_PCH_SOURCES CONFIGURE_DEPENDS src/pch.cpp)
+	list(GET ARCHIMEDES_PCH_SOURCES 0 ARCHIMEDES_PCH_SOURCE)
+	list(REMOVE_ITEM ARCHIMEDES_SOURCE ${ARCHIMEDES_PCH_SOURCE})
+endif()
+
 target_sources(${PROJECT_NAME} PRIVATE ${ARCHIMEDES_SOURCE})
 target_include_directories(${PROJECT_NAME} PUBLIC include)
 

--- a/include/pch.h
+++ b/include/pch.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <codecvt>
+#include <ctre.hpp>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <ranges>
+#include <set>
+#include <source_location>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <Ecs.h>
+#include <Logger.h>
+#include <Meta.h>
+#include <TUtils.h>
+#include <stb_image.h>

--- a/src/pch.cpp
+++ b/src/pch.cpp
@@ -1,0 +1,1 @@
+#include "pch.h"


### PR DESCRIPTION
Times below are not Archimedes build times, they only indicate speed, as in reality generators build files in parallel.

Time before (excluding nvrhi):
- frontend: 464.9s
- backend: 65.4s
- sum: 530.4s

Time after:
- frontend: 125.6s (73% decrease)
- backend: 73.1s (11.7% increase)
- sum: 198.7s (62.5% decrease)