### PR TITLE
Nvrhi fix

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -26,7 +26,7 @@ class Archimedes(ConanFile):
 
         # Vulkan SDK
         self.requires("volk/1.3.268.0")
-        self.requires("vulkan-headers/1.3.268.0", override=True)
+        self.requires("vulkan-headers/1.4.313.0", override=True)
         self.requires("vulkan-memory-allocator/cci.20231120")
 
         # SPIRV (Shader compiler)

--- a/src/platform/nvrhi/context/NvrhiVulkanContext.cpp
+++ b/src/platform/nvrhi/context/NvrhiVulkanContext.cpp
@@ -51,7 +51,7 @@ void NvrhiVulkanContext::init(const Ref<Window>& window) {
 
 	// Dynamically load the Vulkan-Hpp function pointers (used by NVRHI)
 	{
-		const vk::DynamicLoader dl;
+		const vk::detail::DynamicLoader dl;
 		const PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr =
 			dl.getProcAddress<PFN_vkGetInstanceProcAddr>("vkGetInstanceProcAddr");
 		VULKAN_HPP_DEFAULT_DISPATCHER.init(desc.instance, vkGetInstanceProcAddr, desc.device);


### PR DESCRIPTION
- Updated vulkan-headers to 1.4.313.0 to match nvrhi
- ~`vk::DynamicLoader`~ -> `vk::detail::DynamicLoader`

```
[14:42:59] [trace] [src\platform\vulkan\VulkanContext.cpp:277]: Available layers 8:
[14:42:59] [trace] [src\platform\vulkan\VulkanContext.cpp:279]:   - VK_LAYER_NV_optimus
[14:42:59] [trace] [src\platform\vulkan\VulkanContext.cpp:279]:   - VK_LAYER_NV_present
[14:42:59] [trace] [src\platform\vulkan\VulkanContext.cpp:279]:   - VK_LAYER_VALVE_steam_overlay
[14:42:59] [trace] [src\platform\vulkan\VulkanContext.cpp:279]:   - VK_LAYER_VALVE_steam_fossilize
[14:42:59] [trace] [src\platform\vulkan\VulkanContext.cpp:279]:   - VK_LAYER_OW_OVERLAY
[14:42:59] [trace] [src\platform\vulkan\VulkanContext.cpp:279]:   - VK_LAYER_OW_OBS_HOOK
[14:42:59] [trace] [src\platform\vulkan\VulkanContext.cpp:279]:   - VK_LAYER_OBS_HOOK
[14:42:59] [trace] [src\platform\vulkan\VulkanContext.cpp:279]:   - VK_LAYER_OBS_HOOK
[14:42:59] [info] [src\platform\vulkan\VulkanContext.cpp:138]: [Vulkan] Setting up debug messenger
[14:42:59] [warning] [src\platform\vulkan\VulkanContext.cpp:68]: [Vulkan] loader_create_device_chain: Using deprecated and ignored 'ppEnabledLayerNames' member of 'VkDeviceCreateInfo' when creating a Vulkan device.
// vvv this is new i think
[14:42:59] [trace] [src\platform\vulkan\VulkanContext.cpp:68]: [Vulkan] loader_phys_dev_ext_gpa: Adding unknown physical function vkGetPhysicalDeviceCooperativeVectorPropertiesNV to internal store at index 0
[14:42:59] [trace] [src\platform\vulkan\VulkanContext.cpp:68]: [Vulkan] loader_phys_dev_ext_gpa: Driver C:\WINDOWS\System32\DriverStore\FileRepository\nvdmi.inf_amd64_dfdc983b5bba52e5\.\nvoglv64.dll returned ptr 00007FFD49EA1FC2 for vkGetPhysicalDeviceCooperativeVectorPropertiesNV
// ^^^
```