### PR TITLE
Add CMake 3.31.8 installation

### DIFF
--- a/.github/workflows/build_test_and_upload_deps.yml
+++ b/.github/workflows/build_test_and_upload_deps.yml
@@ -38,6 +38,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.8'
+
+      - name: Check CMake version
+        run: |
+          cmake --version
       
       - name: Environment setup
         run: |
@@ -132,6 +141,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.8'
+
+      - name: Check CMake version
+        run: |
+          cmake --version
 
       - name: Environment setup
         run: |

--- a/.github/workflows/upload_engine.yml
+++ b/.github/workflows/upload_engine.yml
@@ -38,6 +38,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.8'
+
+      - name: Check CMake version
+        run: |
+          cmake --version
       
       - name: Environment setup
         run: |
@@ -122,6 +131,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.8'
+
+      - name: Check CMake version
+        run: |
+          cmake --version
 
       - name: Environment setup
         run: |


### PR DESCRIPTION
Runner images `Windows-2025` and `Ubuntu-24.04` will default to CMake 4 since 2025.09.15.
Since CMake 4 is not backwards compatible with older CMake 3s (used by some of our dependencies), this change adds CMake 3.31.8 installation steps to both test and upload jobs.