### PR TITLE
CMake presets + RelWithDebInfo fix

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,29 @@
+{
+	"version": 3,
+	"configurePresets": [
+		{
+			"name": "Debug",
+			"generator": "Ninja",
+			"binaryDir": "${sourceDir}/build/Debug",
+			"cacheVariables": {
+				"CMAKE_BUILD_TYPE": "Debug"
+			}
+		},
+		{
+			"name": "Release",
+			"generator": "Ninja",
+			"binaryDir": "${sourceDir}/build/Release",
+			"cacheVariables": {
+				"CMAKE_BUILD_TYPE": "Release"
+			}
+		},
+		{
+			"name": "RelWithDebInfo",
+			"generator": "Ninja",
+			"binaryDir": "${sourceDir}/build/RelWithDebInfo",
+			"cacheVariables": {
+				"CMAKE_BUILD_TYPE": "RelWithDebInfo"
+			}
+		}
+	]
+}

--- a/cmake/msvc.cmake
+++ b/cmake/msvc.cmake
@@ -6,4 +6,7 @@ if(MSVC)
     add_compile_options("/permissive-")		# Conform to C++ standard
     add_compile_options("/Zc:preprocessor")	# Conform to C++ standard (preprocessor)
     add_compile_options("/Zc:__cplusplus")	# Set the __cplusplus macro
+	
+	# Enable more agressive inling in RelWithDebInfo, the /Ob1 setting is legacy yet still the default
+	string(REPLACE "/Ob1" "/Ob2" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 endif()

--- a/conanfile.py
+++ b/conanfile.py
@@ -107,6 +107,7 @@ class ArchimedesConan(ConanFile):
 
 	def generate(self):
 		tc = CMakeToolchain(self, 'Ninja')
+		tc.user_presets_path = False
 		tc.variables['ARCHIMEDES_SHARED'] = self.options.shared
 		tc.variables['ARCHIMEDES_INSTALL'] = self.options.install
 		tc.variables['ARCHIMEDES_BUILD_TESTS'] = self.options.build_tests

--- a/conanfile_dev.py
+++ b/conanfile_dev.py
@@ -2,7 +2,8 @@
 
 from conan import ConanFile
 from conan.tools.microsoft.visual import is_msvc
-from conan.tools.cmake import cmake_layout
+from conan.tools.cmake import cmake_layout, CMakeToolchain
+
 import re
 import subprocess
 
@@ -19,7 +20,7 @@ class ArchimedesConan(ConanFile):
 	url = 'https://github.com/AGH-Code-Industry/archimedes'
 	description = 'Archimedes Game Engine, @AGH Code Industry'
 	settings = 'os', 'compiler', 'build_type', 'arch'
-	generators = 'CMakeDeps', 'CMakeToolchain'
+	generators = ('CMakeDeps',)
 
 	def requirements(self):
 		self.requires('glfw/3.4')
@@ -59,3 +60,8 @@ class ArchimedesConan(ConanFile):
 			
 	def layout(self):
 		cmake_layout(self)
+
+	def generate(self):
+		tc = CMakeToolchain(self)
+		tc.user_presets_path = False
+		tc.generate()


### PR DESCRIPTION
- [x] Added `CMakePresets.json` with `Debug`, `Release` and `RelWithDebInfo`
- [x] Disabled generation of `CMakeUserPresets.json` by conan
- [x] Fixed [`RelWithDebInfo` having `/Ob1` option instead of `/Ob2`](https://www.reddit.com/r/cpp/comments/1nh2xx3/why_does_cmake_configuration_relwithdebinfo_by/)